### PR TITLE
Email validated

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,5 +1,5 @@
 class RequestsController < ApplicationController
-  before_action :set_request, only: [:confirm_email, :reconfirm_email]
+  before_action :set_request, only: %i[confirm_email reconfirm_email]
 
   def new
     @request = Request.new
@@ -15,13 +15,15 @@ class RequestsController < ApplicationController
     end
   end
 
+  # Confirm email for the first time
   def confirm_email
     @request.update(email_confirmation: true, confirmed_at: Date.today)
     redirect_to new_request_path, notice: 'Your email has been confirmed'
   end
 
+  # Confirm email for the second and final time
   def reconfirm_email
-    @request.update(email_confirmation: true, confirmed_at: Date.today)
+    @request.update(email_validated: true, confirmed_at: Date.today)
     redirect_to new_request_path, notice: 'Your email has been reconfirmed'
   end
 

--- a/app/jobs/confirm_email_job.rb
+++ b/app/jobs/confirm_email_job.rb
@@ -2,6 +2,6 @@ class ConfirmEmailJob < ApplicationJob
   queue_as :default
 
   def perform(request)
-    request.update(request.email_confirmation ? { accepted: true } : { expired: true })
+    request.update(request.email_validated ? { accepted: true } : { expired: true })
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -44,9 +44,6 @@ class Request < ApplicationRecord
       # Send email to reconfirm email
       RequestMailer.reconfirm_email(request).deliver_later
 
-      # Change email_confirmation to false
-      request.update(email_confirmation: false)
-
       # Check if email_confirmation is true, else -> change expired to true
       # ConfirmEmailJob.set(wait: 2.days).perform_later(request)
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -33,6 +33,7 @@ class Request < ApplicationRecord
     RequestMailer.confirm_email(self).deliver_later
   end
 
+  # Send a second email to confirm for the last time if the user is still interested
   def self.send_reconfirm_email
     # For all requests that have been accepted but not confirmed yet
     Request.confirmed.unaccepted.each do |request|
@@ -44,10 +45,9 @@ class Request < ApplicationRecord
       # Send email to reconfirm email
       RequestMailer.reconfirm_email(request).deliver_later
 
-      # Check if email_confirmation is true, else -> change expired to true
+      # Check if email_validated is true, else -> change expired to true
       # ConfirmEmailJob.set(wait: 2.days).perform_later(request)
 
-      puts 'Job is about to be launched'
       ConfirmEmailJob.set(wait: 1.minute).perform_later(request)
     end
   end

--- a/db/migrate/20240702082151_add_email_validated_to_request.rb
+++ b/db/migrate/20240702082151_add_email_validated_to_request.rb
@@ -1,0 +1,5 @@
+class AddEmailValidatedToRequest < ActiveRecord::Migration[7.0]
+  def change
+    add_column :requests, :email_validated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_02_101146) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_02_082151) do
   create_table "requests", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_02_101146) do
     t.datetime "updated_at", null: false
     t.boolean "expired", default: false
     t.date "confirmed_at"
+    t.boolean "email_validated", default: false
   end
 
 end


### PR DESCRIPTION
- [x]  Add email validated to request model and made the appropriate changes in the codebase.

```email_validated``` is passed to ```true``` when the email is **reconfirmed**

Did this change to prevent errors that might happen with cron jobs and active jobs running into each other