### PR TITLE
Needed to check if the request wheren't expired too

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -19,6 +19,8 @@ class Request < ApplicationRecord
   # Requests that have not been reconfirmed
   scope :expired, -> { where(expired: true) }
 
+  scope :unexpired, -> { where(expired: false) }
+
   # Accept a request
   def self.accept!
     Request.confirmed.order(:created_at).first.update(accepted: true)
@@ -36,7 +38,7 @@ class Request < ApplicationRecord
   # Send a second email to confirm for the last time if the user is still interested
   def self.send_reconfirm_email
     # For all requests that have been accepted but not confirmed yet
-    Request.confirmed.unaccepted.each do |request|
+    Request.confirmed.unaccepted.unexpired.each do |request|
       # three_months_from_last_confirmed = request.confirmed_at + 3.months
 
       # next unless three_months_from_last_confirmed == Date.today

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -26,6 +26,6 @@ set :output, 'log/cron.log'
 #   runner "Request.send_reconfirm_email"
 # end
 
-every 5.minutes do
+every 3.minutes do
   runner 'Request.send_reconfirm_email'
 end


### PR DESCRIPTION
There was an error where expired email where still receiving ```reconfirm_email```
To prevent this, I added a scope ```unexpired``` returning all the requests that are not expired, then chained to the 2 other scopes already here.